### PR TITLE
Updated README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #NxPg
-----
+
 
 This README file is a placeholder.  NxPg itself isn't ready yet.
 
@@ -10,7 +10,7 @@ As currently envisioned, NxPg requires some technical knowledge to
 first set up a site -- such as PHP, HTML, and MySQL.  After that,
 someone with little technical background can maintain the contents.
 
-----
+
 ##The backstory:
 
 Several years ago, we at [Unidev][1] developed a website for a local manufacturer.  
@@ -21,7 +21,7 @@ with it.
 Since we retained the copyrights to the code delivered to the client, we 
 can open the source and let others adapt it to their needs.
 
-----
+
 ##The problem:
 
 The client's data is not completely separated from the administrative code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,51 @@
 NxPg
-====
+----
 
-Open source content management for brochure websites.
+This README file is a placeholder.  NxPg itself isn't ready yet.
+
+NxPg is a lightweight Content Management System (CMS) for websites with modest needs.  
+It isn't as capable as a heavyweight CMS like WordPress. It also isn't as complicated.
+
+As currently envisioned, NxPg requires some technical knowledge to
+first set up a site -- such as PHP, HTML, and MySQL.  After that,
+someone with little technical background can maintain the contents.
+
+*The backstory:*
+
+Several years ago, we at [Unidev][1] developed a website for a local manufacturer.  
+The delivered product included administrative tools for the client to maintain the 
+site after the initial setup.  That site is still up, and the client is still happy 
+with it.
+
+Since we retained the copyrights to the code delivered to the client, we 
+can open the source and let others adapt it to their needs.
+
+*The problem:*
+
+The client's data is not completely separated from the administrative code.
+The PHP contains hard-coded references to the client's business.
+
+Before we can publish NxPg, we have to scrub the client-specific stuff
+from the code, and replace it with fictitious data about a fictitious
+company.
+
+We'll also clean up things along the way -- sloppy code if we notice it,
+or various bits and scraps of unnecessary junk.  We'll also add copyright
+notices (NxPg will be licensed under the GNU General Public License,
+version 3).
+
+We'll also have to become familiar with the GitHub tools for on-line
+collaboration.  We'll make mistakes, and probably embarrass ourselves
+from time to time, but that's life in the open source fishbowl.
+
+All of this will take time, and we're just getting started.  If you're
+looking for a lightweight CMS (and you don't need it right away),
+check back later.  Watch NxPg take shape.  Join us.
+
+-----
+
+NxPg was originally created by [Unidev][1], 16690 Swingley Ridge Road, Suite 250, 
+Chesterfield MO, USA, 63017.  Other contributors retain copyright to their 
+contributions.
+
+[1]: http://www.unidev.com/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NxPg
+#NxPg
 ----
 
 This README file is a placeholder.  NxPg itself isn't ready yet.
@@ -10,7 +10,8 @@ As currently envisioned, NxPg requires some technical knowledge to
 first set up a site -- such as PHP, HTML, and MySQL.  After that,
 someone with little technical background can maintain the contents.
 
-*The backstory:*
+----
+##The backstory:
 
 Several years ago, we at [Unidev][1] developed a website for a local manufacturer.  
 The delivered product included administrative tools for the client to maintain the 
@@ -20,7 +21,8 @@ with it.
 Since we retained the copyrights to the code delivered to the client, we 
 can open the source and let others adapt it to their needs.
 
-*The problem:*
+----
+##The problem:
 
 The client's data is not completely separated from the administrative code.
 The PHP contains hard-coded references to the client's business.


### PR DESCRIPTION
I played around with the formatting some. I leaned that different markdown interpreters handle the hash denoted headings differently. Github automatically adds a linebreak after h1 and h2 headers.
